### PR TITLE
Chore: Track total staked volt, rewards, and user count, fix volt price

### DIFF
--- a/subgraphs/bar/bar.fuse.yaml
+++ b/subgraphs/bar/bar.fuse.yaml
@@ -29,3 +29,26 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: transfer
       file: ./src/bar.ts
+  - kind: ethereum/contract
+    name: JoeToken
+    network: fuse
+    source:
+      address: '0x34Ef2Cc892a88415e9f02b91BfA9c91fC0bE6bD4'
+      abi: JoeToken
+      startBlock: 15542382
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - VoltBalanceHistory
+        - Bar
+      abis:
+        - name: JoeToken
+          file: ../../packages/abis/VoltageERC20.json
+        - name: Pair
+          file: ../../packages/abis/VoltagePair.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: voltTransfer
+      file: ./src/bar.ts

--- a/subgraphs/bar/bar.graphql
+++ b/subgraphs/bar/bar.graphql
@@ -50,6 +50,12 @@ type Bar @entity {
 
   # Updated at
   updatedAt: BigInt!
+
+  # volt amounts transferred through enter() call
+  voltEntered: BigDecimal!
+
+  # volt amounts transferred through exit
+  voltExited: BigDecimal!
 }
 
 # User
@@ -139,4 +145,11 @@ type History @entity {
   xVoltBurned: BigDecimal!
   xVoltSupply: BigDecimal!
   ratio: BigDecimal!
+}
+
+type VoltBalanceHistory @entity {
+  id: ID!
+  balance: BigDecimal!
+  balanceUSD: BigDecimal!
+  totalVoltStaked: BigDecimal!
 }

--- a/subgraphs/bar/bar.graphql
+++ b/subgraphs/bar/bar.graphql
@@ -48,6 +48,9 @@ type Bar @entity {
   # Users in the bar
   users: [User!]! @derivedFrom(field: "volt")
 
+  # Active user count in the bar
+  usersCnt: Int!
+
   # Updated at
   updatedAt: BigInt!
 

--- a/subgraphs/bar/package.json
+++ b/subgraphs/bar/package.json
@@ -1,30 +1,26 @@
 {
-    "name": "bar",
-    "license": "MIT",
-    "version": "1.0.0",
-    "author": "Trader Joe",
-    "scripts": {
-	    "prepare:avax": "mustache config/avax.json bar.template.yaml > bar.avax.yaml",
-        "prepare:rinkeby": "mustache config/rinkeby.json bar.template.yaml > bar.rinkeby.yaml",
-        "prepare:fuji": "mustache config/fuji.json bar.template.yaml > bar.fuji.yaml",
-        "prepare:fuse": "mustache config/fuse.json bar.template.yaml > bar.fuse.yaml",
-
-        "codegen:avax": "graph codegen bar.avax.yaml",
-        "codegen:rinkeby": "graph codegen bar.rinkeby.yaml",
-        "codegen:fuji": "graph codegen bar.fuji.yaml",
-        "codegen:fuse": "graph codegen bar.fuse.yaml",
-
-        "build:avax": "graph build bar.avax.yaml",
-        "build:rinkeby": "graph build bar.rinkeby.yaml",
-        "build:fuji": "graph build bar.fuji.yaml",
-        "build:fuse": "graph build bar.fuse.yaml",
-
-        "deploy:avax": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ traderjoe-xyz/bar bar.avax.yaml",
-        "deploy:rinkeby": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ traderjoe-xyz/bar-rinkeby-ii bar.rinkeby.yaml",
-        "deploy:fuse": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ voltfinance/bar bar.fuse.yaml",
-
-        "create-local": "graph create --node http://localhost:8020/ traderjoe-xyz/bar",
-        "remove-local": "graph remove --node http://localhost:8020/ traderjoe-xyz/bar",
-        "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 traderjoe-xyz/bar bar.fuji.yaml"
-    }
+  "name": "bar",
+  "license": "MIT",
+  "version": "1.0.0",
+  "author": "Trader Joe",
+  "scripts": {
+    "prepare:avax": "mustache config/avax.json bar.template.yaml > bar.avax.yaml",
+    "prepare:rinkeby": "mustache config/rinkeby.json bar.template.yaml > bar.rinkeby.yaml",
+    "prepare:fuji": "mustache config/fuji.json bar.template.yaml > bar.fuji.yaml",
+    "prepare:fuse": "mustache config/fuse.json bar.template.yaml > bar.fuse.yaml",
+    "codegen:avax": "graph codegen bar.avax.yaml",
+    "codegen:rinkeby": "graph codegen bar.rinkeby.yaml",
+    "codegen:fuji": "graph codegen bar.fuji.yaml",
+    "codegen:fuse": "graph codegen bar.fuse.yaml",
+    "build:avax": "graph build bar.avax.yaml",
+    "build:rinkeby": "graph build bar.rinkeby.yaml",
+    "build:fuji": "graph build bar.fuji.yaml",
+    "build:fuse": "graph build bar.fuse.yaml",
+    "deploy:avax": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ traderjoe-xyz/bar bar.avax.yaml",
+    "deploy:rinkeby": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ traderjoe-xyz/bar-rinkeby-ii bar.rinkeby.yaml",
+    "deploy:fuse": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ t0mcr8se/voltbar bar.fuse.yaml",
+    "create-local": "graph create --node http://localhost:8020/ volt/bar",
+    "remove-local": "graph remove --node http://localhost:8020/ volt/bar",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 volt/bar bar.fuse.yaml"
+  }
 }

--- a/subgraphs/bar/src/bar.ts
+++ b/subgraphs/bar/src/bar.ts
@@ -62,8 +62,8 @@ function createBar(block: ethereum.Block): Bar {
   return bar as Bar
 }
 
-function createVoltBalanceHistory(block: ethereum.Block): VoltBalanceHistory {
-  const vbh = new VoltBalanceHistory(block.number.toString())
+function createVoltBalanceHistory(day: string): VoltBalanceHistory {
+  const vbh = new VoltBalanceHistory(day)
   vbh.balance = BIG_DECIMAL_ZERO
   vbh.balanceUSD = BIG_DECIMAL_ZERO
   vbh.totalVoltStaked = BIG_DECIMAL_ZERO
@@ -83,10 +83,13 @@ function getBar(block: ethereum.Block): Bar {
 }
 
 function getVoltBalanceHistory(block: ethereum.Block): VoltBalanceHistory {
-  let vbh = VoltBalanceHistory.load(block.number.toString())
+  const day = block.timestamp.toI32() / 86400
+  const id = BigInt.fromI32(day).toString()
+
+  let vbh = VoltBalanceHistory.load(id)
 
   if (vbh === null) {
-    vbh = createVoltBalanceHistory(block)
+    vbh = createVoltBalanceHistory(id)
   }
 
   return vbh as VoltBalanceHistory

--- a/subgraphs/bar/src/bar.ts
+++ b/subgraphs/bar/src/bar.ts
@@ -1,7 +1,6 @@
 import {
   ADDRESS_ZERO,
   BIG_DECIMAL_1E18,
-  BIG_DECIMAL_1E6,
   BIG_DECIMAL_ZERO,
   BIG_INT_ZERO,
   VOLT_BAR_ADDRESS,
@@ -29,7 +28,7 @@ function getVoltPrice(): BigDecimal {
     log.error('[getJoePrice] USDC reserve 0', [])
     return BIG_DECIMAL_ZERO
   }
-  return reserves.value1.toBigDecimal().times(BIG_DECIMAL_1E18).div(reserves.value0.toBigDecimal()).div(BIG_DECIMAL_1E6)
+  return reserves.value1.toBigDecimal().times(BIG_DECIMAL_1E18).div(reserves.value0.toBigDecimal()).div(BIG_DECIMAL_1E18)
 }
 
 function createBar(block: ethereum.Block): Bar {

--- a/subgraphs/bar/src/bar.ts
+++ b/subgraphs/bar/src/bar.ts
@@ -57,6 +57,7 @@ function createBar(block: ethereum.Block): Bar {
   bar.updatedAt = block.timestamp
   bar.voltEntered = BIG_DECIMAL_ZERO
   bar.voltExited = BIG_DECIMAL_ZERO
+  bar.usersCnt = 0
   bar.save()
 
   return bar as Bar
@@ -208,6 +209,7 @@ export function transfer(event: TransferEvent): void {
     if (user.xVolt == BIG_DECIMAL_ZERO) {
       log.info('{} entered the bar', [user.id])
       user.volt = bar.id
+      bar.usersCnt = bar.usersCnt + 1
     }
 
     user.xVoltMinted = user.xVoltMinted.plus(value)
@@ -281,6 +283,7 @@ export function transfer(event: TransferEvent): void {
     if (user.xVolt == BIG_DECIMAL_ZERO) {
       log.info('{} left the bar', [user.id])
       user.volt = null
+      bar.usersCnt = bar.usersCnt - 1
     }
 
     user.updatedAt = event.block.timestamp
@@ -336,6 +339,7 @@ export function transfer(event: TransferEvent): void {
     if (fromUser.xVolt == BIG_DECIMAL_ZERO) {
       log.info('{} left the bar by transfer OUT', [fromUser.id])
       fromUser.volt = null
+      bar.usersCnt = bar.usersCnt - 1
     }
 
     fromUser.save()
@@ -345,6 +349,7 @@ export function transfer(event: TransferEvent): void {
     if (toUser.volt === null) {
       log.info('{} entered the bar by transfer IN', [fromUser.id])
       toUser.volt = bar.id
+      bar.usersCnt = bar.usersCnt + 1
     }
 
     // Recalculate xJoe age and add incoming xJoeAgeTransfered


### PR DESCRIPTION
## What was done:
- Tracked volt transfers from and to voltbar
- Tracked volt that was entered through enter call
- Tracked volt that was exited through exit call
- Tracked active user count
- Fixed Volt price that was messing up USD values

## Why?
To calculate the rewards, APY, and user count easily 